### PR TITLE
ci: bump nais/fasit-deploy to v4.0.0

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -58,26 +58,21 @@ jobs:
       - name: Push Chart
         run: |-
           helm push tokenx-${{ env.NAME }}*.tgz ${{ env.FEATURE_REPOSITORY }}
-  rollout:
+  deploy:
     needs:
       - build_and_push
     runs-on: fasit-deploy
     permissions:
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: '{"kind":"tenant","tenant":"dev-nais"}'
-            skip-ci: false
-          - target: '{"kind":"onprem","tenant":"nav"}'
-            skip-ci: true
-          - target: '{"kind":"tenant","tenant":"nav"}'
-            skip-ci: false
     steps:
-      - uses: nais/fasit-deploy@6e5772c21e82cb101537dd5e3ce78d70e2ae6402 # ratchet:nais/fasit-deploy@v3
+      - uses: nais/fasit-deploy@97187355184a7f0f4b7a36a2b49a86ce02240f7b # ratchet:nais/fasit-deploy@v4.0.0
         with:
           chart: ${{ env.FEATURE_REPOSITORY }}/tokenx-${{ env.NAME }}
           version: ${{ needs.build_and_push.outputs.version }}
-          skip-ci: ${{ matrix.skip-ci }}
-          target: ${{ matrix.target }}
+          targets: |
+            [
+              { "target": { "kind": "tenant", "tenant": "ci-nais" }, "wait": true },
+              { "target": { "kind": "tenant", "tenant": "dev-nais" } },
+              { "target": { "kind": "tenant", "tenant": "nav" } },
+              { "target": { "kind": "onprem", "tenant": "nav" } }
+            ]


### PR DESCRIPTION
v4 is a breaking rewrite of the action:

- Node 24 JS action (no helm/gcloud on runner)
- `target` (single object) → `targets` (JSON list of `{target, wait}` entries)
- Drops `skip-ci`, `global`, `all-environments`, `google_service_account`, `workload_identity_provider`
- Authenticates via GitHub OIDC to the new fasit deployment endpoint

Where v3 default `skip-ci: false` implicitly prepended a ci-target, the new list explicitly starts with `tenant:ci-nais` (or `management:ci-nais`) using `wait: true` before the production fan-out.

Also renames the `rollout` job to `deploy` to align with the v4 deployment-konsept.

See https://github.com/nais/fasit-deploy/releases/tag/v4.0.0 for full migration notes.